### PR TITLE
Elyra code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,6 +1,6 @@
 <!--
 {% comment %}
-Copyright 2018-2019 IBM Corporation
+Copyright 2018-2020 IBM Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,107 +16,73 @@ limitations under the License.
 {% endcomment %}
 -->
 
-# Elyra Code of Conduct
+## Elyra Community Code of Conduct 1.0
 
-## Introduction
 
-Project Elyra is an engaged and respectful community. As contributors and maintainers of this project,
-and in the interest of fostering an open and welcoming community, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating documentation, submitting 
-pull requests or patches, and other activities.
+### Our Pledge
 
-We are committed to making participation in this project a harassment-free experience for everyone, 
-regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, 
-personal appearance, body size, race, ethnicity, age, religion, or nationality.
+As contributors and maintainers of this project, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
 
-This code of conduct applies to all spaces related and/or managed by the Elyra contributors, including Gitter,
-issue trackers, wikis, blogs, Twitter, and any other communication channel used by our community.
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code,
-wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this
-Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles
-to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct
-may be permanently removed from the project team.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
 
-We expect this code of conduct to be honored by everyone who participates in the Elyra community
-formally or informally, or claims any affiliation with Elyra, in any project-related activities
-and especially when representing the project or its community, in any role.
+### Our Standards
 
-This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative,
-shared environment and goals. We expect it to be followed in spirit as much as in the letter, so that it can
-enrich all of us and the technical communities in which we participate.
+Examples of behavior that contributes to a positive environment for our community include:
 
-## Specific Guidelines
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-We strive to:
+Examples of unacceptable behavior include:
 
- * Be open. We invite anyone to participate in our community. We preferably use public methods of communication
-   for project-related messages, unless discussing something sensitive. This applies to messages for help or 
-   project-related support, too; not only is a public support request much more likely to result in an answer
-   to a question, it also makes sure that any inadvertent mistakes made by people answering will be more easily
-   detected and corrected.
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
- * Be empathetic, welcoming, friendly, and patient. We work together to resolve conflict, assume good intentions,
-   and do our best to act in an empathetic fashion. We may all experience some frustration from time to time,
-   but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable 
-   or threatened is not a productive one. We should be respectful when dealing with other community members as 
-   well as with people outside our community.
+## Enforcement Responsibilities
 
- * Be collaborative. Our work will be used by other people, and in turn we will depend on the work of others.
-   When we make something for the benefit of the project, we are willing to explain to others how it works,
-   so that they can build on the work to make it even better. Any decision we make will affect users and colleagues,
-   and we take those consequences seriously when making decisions.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
 
- * Be inquisitive. Nobody knows everything! Asking questions early avoids many problems later, so questions are
-   encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and
-   helpful, within the context of our shared goal of improving Apache project code.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
+and will communicate reasons for moderation decisions when appropriate.
 
- * Be careful in the words that we choose. Whether we are participating as professionals or volunteers, 
-   we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. 
-   Do not insult or put down other participants. Harassment and other exclusionary behaviour are not acceptable. 
-   This includes, but is not limited to:
-   
-   * Violent threats or language directed against another person.
-   * Sexist, racist, or otherwise discriminatory jokes and language.
-   * Posting sexually explicit or violent material.
-   * Posting (or threatening to post) other people's personally identifying information ("doxing").
-   * Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
-   * Personal insults, especially those using racist or sexist terms.
-   * Unwelcome sexual attention.
-   * Excessive or unnecessary profanity.
-   * Repeated harassment of others. In general, if someone asks you to stop, then stop.
-   * Advocating for, or encouraging, any of the above behaviour.
+## Scope
 
- * Be concise. Keep in mind that what you write once will be read by hundreds of persons. Writing a short email means
-   people can understand the conversation as efficiently as possible. Short emails should always strive to be empathetic,
-   welcoming, friendly and patient. When a long explanation is necessary, consider adding a summary.
+This Code of Conduct applies within all community spaces including Gitter, issue trackers, wikis,
+blogs, Twitter, and any other communication channels used by our community, and also applies when
+an individual is officially representing the community in public spaces. Examples of representing
+our community include using an official e-mail address, posting via an official social media account,
+or acting as an appointed representative at an online or offline event.
 
- * Try to bring new ideas to a conversation so that each mail adds something unique to the thread, keeping in mind
-   that the rest of the thread still contains the other messages with arguments that have already been made.
+## Enforcement
 
- * Try to stay on topic, especially in discussions that are already fairly large.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community
+leaders responsible for enforcement via e-mail to the Elyra Project Management Committee at
+elyra-pmc AT googlegroups DOT com. All complaints will be reviewed and investigated promptly and fairly.
 
- * Step down considerately. Members of every project come and go. When somebody leaves or disengages from the
-   project they should tell people they are leaving and take the proper steps to ensure that others can pick up
-   where they left off. In doing so, they should remain respectful of those who continue to participate in the
-   project and should not misrepresent the project's goals or achievements. Likewise, community members should
-   respect any individual's choice to leave the project.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
-## Reporting Guidelines
 
-While this code of conduct should be adhered to by participants, we recognize that sometimes people may have a
-bad day, or be unaware of some of the guidelines in this code of conduct. When that happens, you may reply to
-them and point out this code of conduct. Such messages may be in public or in private, whatever is most
-appropriate. However, regardless of whether the message is public or not, it should still adhere to the
-relevant parts of this code of conduct; in particular, it should not be abusive or disrespectful.
+## Attribution
 
-If you believe someone is violating this code of conduct, you may reply to them and point out this
-code of conduct. Such messages may be in public or in private, whatever is most appropriate. Assume good faith;
-it is more likely that participants are unaware of their bad behaviour than that they intentionally try to
-degrade the quality of the discussion. Should there be difficulties in dealing with the situation, 
-you may report your compliance issues in confidence to either one of our volunteers:
-
-    Luciano Resende - lresende AT us DOT ibm DOT com
-    Kevin Bates
-    Alex Bozarth
-    Alan Chin
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.


### PR DESCRIPTION
Elyra community code of conduct  based on
[Contributor Covenant](https://www.contributor-covenant.org/) version 2.0 available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html